### PR TITLE
Optimize regexes and fix font regex issue

### DIFF
--- a/lib/h5bp.js
+++ b/lib/h5bp.js
@@ -27,19 +27,19 @@ var h5bp,
 	ONE_YEAR = ONE_MONTH * 12,
 
 	/** mime type regexps */
-	RE_MIME_IMAGE = /image/,
-	RE_MIME_FONT = /(application\/(font-woff|x-font-ttf|vnd\.ms-fontobject|font\/opentype))/,
-	RE_MIME_DATA = /(text\/(cache-manifest|html|xml)|application\/(xml|json))/,
-	RE_MIME_FEED = /application\/(rss\+xml|atom\+xml)/,
-	RE_MIME_FAVICON = /image\/x-icon/,
-	RE_MIME_MEDIA = /(image|video|audio|text\/x-component|application\/(font-woff|x-font-ttf|vnd\.ms-fontobject|font\/opentype))/,
-	RE_MIME_CSSJS = /(text\/(css|x-component)|application\/javascript)/,
+	RE_MIME_IMAGE = /^image/,
+	RE_MIME_FONT = /^(?:application\/(?:font-woff|x-font-ttf|vnd\.ms-fontobject)|font\/opentype)$/,
+	RE_MIME_DATA = /^(?:text\/(?:cache-manifest|html|xml)|application\/(?:xml|json))$/,
+	RE_MIME_FEED = /^application\/(?:rss|atom)\+xml$/,
+	RE_MIME_FAVICON = /^image\/x-icon$/,
+	RE_MIME_MEDIA = /(image|video|audio|text\/x-component|application\/(?:font-woff|x-font-ttf|vnd\.ms-fontobject)|font\/opentype)/,
+	RE_MIME_CSSJS = /^(?:text\/(?:css|x-component)|application\/javascript)$/,
 
 	/** misc regexps */
 	RE_WWW = /^www\./,
 	RE_MSIE = /MSIE/,
 	RE_HIDDEN = /(^|\/)\./,
-	RE_SRCBAK = /\.(bak|config|sql|fla|psd|ini|log|sh|inc|swp|dist)|~/,
+	RE_SRCBAK = /\.(?:bak|config|sql|fla|psd|ini|log|sh|inc|swp|dist)|~/,
 
 	/** default (apache) mime types */
 	mime = express.mime;


### PR DESCRIPTION
I've optimized the regular expressions by using non-capturing groups, eg., `(?:a|b)` and I also added `^` and `$` regex tokens where appropriate. Also, there was an issue with one of the font regexes where instead of testing for `font/opentype` it tested for `application/font/opentype`.
