### PR TITLE
Stylus stylesheet Compiling

### DIFF
--- a/lib/h5bp.js
+++ b/lib/h5bp.js
@@ -33,7 +33,7 @@ h5bp = module.exports = function(options) {
 		},
 		{
 			type: 'stylesheets',
-			processors: /sass|less/,
+			processors: /sass|less|stylus/,
 			defaultProcessor: 'sass'
 		}
 	].forEach(function(resource) {

--- a/lib/layers/stylus.js
+++ b/lib/layers/stylus.js
@@ -1,0 +1,72 @@
+/*jslint node:true nomen:true white:true eqeq:true */
+'use strict';
+
+/** deps */
+var path = require('path'),
+	fs = require('fs'),
+	processor = require('stylus'),
+	Cache = require('connect/lib/cache'),
+	cache = new Cache();
+
+/**
+ * Configures stylus layer.
+ * @type {Function}
+ */
+module.exports = function(options) {
+	var files = options.stylesheets.files,
+		envDev = 'development' == process.env.NODE_ENV;
+
+	// removes all leading slashs if any
+	files = files.map(function(entry) {
+		return ('/' == entry.charAt('/') ? entry.slice(1) : entry);
+	});
+
+	function respond(res, entry, cacheHeader) {
+		res.setHeader('Content-Type', 'text/css');
+		res.setHeader('X-Cache', cacheHeader);
+		res.send(200, entry[0]);
+	}
+
+	/**
+	 * The actual Stylus layer, invoked for each request hit.
+	 * Compiles a Stylus file into a CSS file.
+	 *
+	 * This is meant to be used with cache busting.
+	 */
+	return function stylus(req, res, next) {
+		var baseUrl = req.baseUrl.slice(1),
+			url = req.url.slice(1),
+			entry;
+
+		if (-1 != files.indexOf(url)) {
+			// cache hit!
+			if (!envDev && (entry = cache.get(baseUrl))) {
+				respond(res, entry, 'HIT');
+				return;
+			}
+
+			// cache miss
+			var filename = path.join(options.root, url).replace(/\.css$/, '.styl');
+			fs.readFile(filename, 'utf8', function(err, content) {
+				if (err) {
+					next(500);
+					return;
+				}
+
+				processor.render(content, { filename: filename }, function(err, content) {
+					if (err) {
+						next(500);
+						return;
+					}
+
+					entry = cache.add(baseUrl);
+					entry.push(content);
+					respond(res, entry, 'MISS');
+				});
+			});
+		}
+		else {
+			next(null, req, res);
+		}
+	};
+};

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 		"async": "0.2.x",
 		"webmake": "~0.3.14",
 		"requirejs": "~2.1.5",
-		"node-sass": "~0.4.3"
+		"node-sass": "~0.4.3",
+		"stylus": "~0.32.1"
 	},
 	"devDependencies": {
 		"mocha": "1.8.x",

--- a/test/fixtures/deep/stylus.styl
+++ b/test/fixtures/deep/stylus.styl
@@ -1,0 +1,2 @@
+body
+  background #133742

--- a/test/fixtures/stylus.styl
+++ b/test/fixtures/stylus.styl
@@ -1,0 +1,2 @@
+body
+  background #fe57a1

--- a/test/h5bp.js
+++ b/test/h5bp.js
@@ -614,6 +614,67 @@ describe('h5bp', function() {
 				});
 			});
 
+			describe('using stylus', function() {
+				it('should compile a file directly at the root level', function(done) {
+					helper.stop()
+						.create({ stylesheets: { files: ['stylus.css'], processor: 'stylus' } })
+						.start()
+						.request()
+						.get('/stylus.css')
+						.expect('content-type', 'text/css')
+						.expect(200)
+						.end(function(err, res) {
+							res.text.should.match(/background: #fe57a1/);
+							done();
+						});
+				});
+
+				it('should cache the previous file', function(done) {
+					helper.stop()
+						.create({ stylesheets: { files: ['stylus.css'], processor: 'stylus' } })
+						.start()
+						.request()
+						.get('/stylus.css')
+						.expect(200)
+						.end(function(err, res) {
+							// supertest seems to bug, doing check here...
+							res.headers['x-cache'].should.equal('HIT');
+							done();
+						});
+				});
+
+				it('should concatenate a file more deep in the hierarchy', function(done) {
+					helper.stop()
+						.create({ stylesheets: { files: ['deep/stylus.css'], processor: 'stylus' } })
+						.start()
+						.request()
+						.get('/deep/stylus.css')
+						.expect('content-type', 'text/css')
+						.expect(200)
+						.end(function(err, res) {
+							res.text.should.match(/background: #133742/);
+							done();
+						});
+				});
+
+				it('should serve an always fresh version of the file', function(done) {
+					process.env.NODE_ENV = 'development';
+					helper.stop()
+						.create({ stylesheets: { files: ['stylus.css'], processor: 'stylus' } })
+						.start()
+						.request()
+						.get('/stylus.css')
+						.expect(200)
+						.end(function(err, res) {
+							// supertest seems to bug, doing check here...
+							res.headers['x-cache'].should.equal('MISS');
+							process.env.NODE_ENV = 'test';
+							done();
+						});
+				});
+			});
+
+
 			it('should default to SASS', function(done) {
 				helper.stop()
 					.create({ stylesheets: { files: ['sass.css'] } })


### PR DESCRIPTION
I've added Stylus support, with the same syntax:

```
stylesheets: {
  files: 'abc.css',
  processor: 'stylus'
}
```

This converts internally to `abc.styl`.
