### PR TITLE
Use only the path portion of the url to lookup mime type 

### DIFF
--- a/lib/layers/headers.js
+++ b/lib/layers/headers.js
@@ -5,7 +5,6 @@
 var path = require('path'),
 	express = require('express'),
 	async = require('async'),
-	nodeurl = require('url'),
 
 	/** cache values */
 	ONE_HOUR = 60 * 60,
@@ -45,6 +44,7 @@ module.exports = function(options) {
 	 */
 	return function headersLayer(req, res, next) {
 		var url = req.url,
+		  pathname = req.path || '/',
 			host = req.headers.host,
 			ua = req.headers['user-agent'],
 			cc = '',
@@ -140,9 +140,8 @@ module.exports = function(options) {
 			// If the url does not contain any valid file extension, let other middlewares handle the `content-type`.
 			// It may be some dynamic content handled by express router for example.
 
-			var urlPath = nodeurl.parse(url).pathname;
-			if (!/\/$/.test(urlPath)) {
-				type = mime.lookup(urlPath);
+			if (!/\/$/.test(pathname)) {
+				type = mime.lookup(pathname);
 				res.setHeader('Content-Type', type);
 			}
 


### PR DESCRIPTION
Lookups were failing when query params existed on the path, resulting
in a content-type of application/octet-stream.

Using the path instead resolves this issue.

Note: in some cases, path is undefined.  This caused one of the connect
unit tests to fail: `should create a connect server`

Since connect and express seem to behave differently in some cases
perhaps it would be worthwhile updating the unit tests to run all
against each type of supported server.

related to #7
related to #10
