### PR TITLE
Remove "h5bp" keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
 		"test": "npm run lint && mocha test --reporter dot --globals requirejsVars --bail"
 	},
 	"keywords": [
-		"h5bp",
 		"html5",
 		"boilerplate",
 		"express",


### PR DESCRIPTION
npm or any other package manager will find h5bp with "h5bp" keyword because it's package name.
