### PR TITLE
Readme: fix `npm` badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **HTML5 boilerplate** (H5BP) server config for node.js.
 
-[![NPM](https://nodei.co/npm/h5bp.svg)](https://nodei.co/npm/h5bp/)
+[![NPM](https://nodei.co/npm/h5bp.png)](https://nodei.co/npm/h5bp/)
 
 [![Build Status](https://secure.travis-ci.org/h5bp/server-configs-node.svg)](http://travis-ci.org/h5bp/server-configs-node)
 [![Dependency Status](https://david-dm.org/h5bp/server-configs-node.svg?theme=shields.io)](https://david-dm.org/h5bp/server-configs-node)


### PR DESCRIPTION
https://nodei.co has no support for the svg `npm` badge. We should simply use the `png` version.
