### PR TITLE
allow option to allow dot files

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Forces **www** if `true`, forces **non-www** if `false`, does nothing if not def
 
 Enables **CORS** for everything. By default this is disabled.
 
+### dotfiles
+
+Enables access to dotfiles. By default this is disabled.
+
 ### scripts
 
 Tells which scripts to concatenate.

--- a/lib/h5bp.js
+++ b/lib/h5bp.js
@@ -107,6 +107,9 @@ h5bp = module.exports = function(options) {
  * @param {Boolean} [options.cors=false] true or false.
  * Enabled CORS for everything.
  *
+ * @param {Boolean} [options.dotfiles=false] true or false.
+ * Enables access to dotfiles.
+ *
  * @param {Boolean} options.www true or false.
  * Force www if true, force non-www if false, does nothing if undefined.
  *

--- a/lib/layers/headers.js
+++ b/lib/layers/headers.js
@@ -53,7 +53,7 @@ module.exports = function(options) {
 		// period. This includes directories used by version control systems such as
 		// Subversion or Git.
 
-		if (RE_HIDDEN.test(pathname)) {
+		if (!options.dotfiles && RE_HIDDEN.test(pathname)) {
 			next(403);
 			return;
 		}

--- a/test/h5bp.js
+++ b/test/h5bp.js
@@ -355,6 +355,38 @@ describe('h5bp', function() {
 						.expect(403, done);
 				});
 			});
+
+			it('should be blocked on express when initiated without option dotfiles', function(done) {
+				var app = express();
+				app.use(h5bp());
+				app.get('/.file', function(req, res) {
+					res.end('ok');
+				});
+				var server = app.listen(8084);
+				request(server)
+					.get('/.file')
+					.expect(403, function() {
+						server.close();
+						done();
+					});
+			});
+
+			it('should not be blocked on express when initiated with option dotfiles', function(done) {
+				var app = express();
+				app.use(h5bp({
+					dotfiles: true
+				}));
+				app.get('/.file', function(req, res) {
+					res.end('ok');
+				});
+				var server = app.listen(8084);
+					request(server)
+					.get('/.file')
+					.expect(200, function() {
+						server.close();
+						done();
+					});
+			});
 		});
 
 		describe('access to backup and source files', function() {


### PR DESCRIPTION
In my app i expose routes that are used to lookup dotfiles in a backend api.  I have no dotfiles I wish to protect.  Is there a problem with adding the ability to allow dotfiles like?:

```
app.use(h5bp({
    allowDotfiles: true
}));
```
